### PR TITLE
1124008_button disabled after processing starts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Release Information
 
-- **Version**: 1.0.0
+- **Version**: 1.0.1
 
 - **Certified**: Yes
 

--- a/widget/edit.controller.js
+++ b/widget/edit.controller.js
@@ -1,16 +1,16 @@
 /* Copyright start
   MIT License
-  Copyright (c) 2024 Fortinet Inc
+  Copyright (c) 2025 Fortinet Inc
   Copyright end */
 'use strict';
 (function () {
     angular
         .module('cybersponse')
-        .controller('editPlaybookExecutionWizard100Ctrl', editPlaybookExecutionWizard100Ctrl);
+        .controller('editPlaybookExecutionWizard101Ctrl', editPlaybookExecutionWizard101Ctrl);
 
-    editPlaybookExecutionWizard100Ctrl.$inject = ['$scope', '$uibModalInstance', 'config'];
+    editPlaybookExecutionWizard101Ctrl.$inject = ['$scope', '$uibModalInstance', 'config'];
 
-    function editPlaybookExecutionWizard100Ctrl($scope, $uibModalInstance, config) {
+    function editPlaybookExecutionWizard101Ctrl($scope, $uibModalInstance, config) {
         $scope.cancel = cancel;
         $scope.save = save;
         $scope.config = config;

--- a/widget/edit.html
+++ b/widget/edit.html
@@ -1,6 +1,6 @@
 <!-- Copyright start
   MIT License
-  Copyright (c) 2024 Fortinet Inc
+  Copyright (c) 2025 Fortinet Inc
   Copyright end -->
 <form data-ng-submit="save()" class="noMargin" name="editWidgetForm" data-ng-class="{'state-wait': processing }"
     novalidate>

--- a/widget/info.json
+++ b/widget/info.json
@@ -2,15 +2,15 @@
     "name": "playbookExecutionWizard",
     "title": "Playbook Execution Wizard",
     "subTitle": "The Playbook Execution Wizard widget renders playbook execution logs and related comments on the wizard",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "published_date": 1703148258,
     "metadata": {
         "description": "The Playbook Execution Wizard widget renders playbook execution logs and related comments on the wizard for a more fine-grained control on your processes",
-        "help_online": "https://github.com/fortinet-fortisoar/widget-playbook-execution-wizard/blob/release/1.0.0/README.md",
+        "help_online": "https://github.com/fortinet-fortisoar/widget-playbook-execution-wizard/blob/release/1.0.1/README.md",
         "snapshots": [
-            "https:\/\/repo.fortisoar.fortinet.com\/widgets\/playbookExecutionWizard-1.0.0\/images\/start_page.png",
-            "https:\/\/repo.fortisoar.fortinet.com\/widgets\/playbookExecutionWizard-1.0.0\/images\/task_page.png",
-            "https:\/\/repo.fortisoar.fortinet.com\/widgets\/playbookExecutionWizard-1.0.0\/images\/finish_page.png"
+            "https:\/\/repo.fortisoar.fortinet.com\/widgets\/playbookExecutionWizard-1.0.1\/images\/start_page.png",
+            "https:\/\/repo.fortisoar.fortinet.com\/widgets\/playbookExecutionWizard-1.0.1\/images\/task_page.png",
+            "https:\/\/repo.fortisoar.fortinet.com\/widgets\/playbookExecutionWizard-1.0.1\/images\/finish_page.png"
         ],
         "pages": [],
         "certified": "Yes",

--- a/widget/view.controller.js
+++ b/widget/view.controller.js
@@ -1,22 +1,21 @@
 /* Copyright start
   MIT License
-  Copyright (c) 2024 Fortinet Inc
+  Copyright (c) 2025 Fortinet Inc
   Copyright end */
 'use strict';
 (function () {
   angular
     .module('cybersponse')
-    .controller('playbookExecutionWizard100Ctrl', playbookExecutionWizard100Ctrl);
+    .controller('playbookExecutionWizard101Ctrl', playbookExecutionWizard101Ctrl);
 
-  playbookExecutionWizard100Ctrl.$inject = ['$scope', '$q', 'WizardHandler', '$resource', 'API', '$uibModal', '_', 'Entity', '$filter', 'websocketService', '$http', 'usersService', 'playbookService', 'toaster', '$state', 'currentPermissionsService', 'ALL_RECORDS_SIZE', 'CommonUtils', '$rootScope', '$timeout', '$anchorScroll', 'widgetBasePath'];
+  playbookExecutionWizard101Ctrl.$inject = ['$scope', '$q', 'WizardHandler', '$resource', 'API', '$uibModal', '_', 'Entity', '$filter', 'websocketService', '$http', 'usersService', 'playbookService', 'toaster', '$state', 'currentPermissionsService', 'ALL_RECORDS_SIZE', 'CommonUtils', '$rootScope', '$timeout', '$anchorScroll', 'widgetBasePath'];
 
-  function playbookExecutionWizard100Ctrl($scope, $q, WizardHandler, $resource, API, $uibModal, _, Entity, $filter, websocketService, $http, usersService, playbookService, toaster, $state, currentPermissionsService, ALL_RECORDS_SIZE, CommonUtils, $rootScope, $timeout, $anchorScroll, widgetBasePath) {
+  function playbookExecutionWizard101Ctrl($scope, $q, WizardHandler, $resource, API, $uibModal, _, Entity, $filter, websocketService, $http, usersService, playbookService, toaster, $state, currentPermissionsService, ALL_RECORDS_SIZE, CommonUtils, $rootScope, $timeout, $anchorScroll, widgetBasePath) {
     $scope.showDataWizard = false;
     $scope.close = close;
     $scope.moveNext = moveNext;
     $scope.moveFinishNext = moveFinishNext;
     $scope.movePrevious = movePrevious;
-    $scope.executeGridPlaybook = executeGridPlaybook;
     $scope.playbookDetails = '';
     $scope.playbookDescription = '';
     $scope.triggerStep = {};
@@ -42,6 +41,8 @@
     $scope.taskIcon = widgetBasePath + 'widgetAssets/images/task.png';
     $scope.finishIcon = widgetBasePath + 'widgetAssets/images/finish.png';
     $scope.activeTab = $state.params.tab === 'logs' ? 2 : 1;
+    $scope.disableStartButton = false;
+
     $scope.$watch('activeTab', function ($newTab, $oldTab) {
       if (!$oldTab) {
         // skip first run
@@ -142,6 +143,7 @@
     }
 
     function moveNext() {
+      $scope.disableStartButton = true;
       loadPlaybookData($state.params.tab);
       if ($scope.jsonToGrid) {
         _checkTaskRecord();
@@ -304,6 +306,8 @@
               triggerPlaybookWithRecords(playbook, triggerStep.arguments.resources[0], $scope.payload.selectedRecord, result).then(function (workflowID) {
                 deferred.resolve();
               });
+            }, function(){
+                $scope.disableStartButton = false; //on modal dismiss 
             });
           } else {
             triggerPlaybookWithRecords(playbook, triggerStep.arguments.resources[0], $scope.payload.selectedRecord, { inputVariables: {} }).then(function (workflowID) {

--- a/widget/view.html
+++ b/widget/view.html
@@ -1,6 +1,6 @@
 <!-- Copyright start
   MIT License
-  Copyright (c) 2024 Fortinet Inc
+  Copyright (c) 2025 Fortinet Inc
   Copyright end -->
 <link rel="stylesheet" type="text/css" href="{{widgetCSS}}" />
 <div class="modal-header">
@@ -22,7 +22,7 @@
                             <div class="padding-right-30 margin-top-sm max-width-450px">
                                 <p class="font-size-14 margin-bottom-0" data-ng-bind-html="playbookDetails"></p>
                             </div>
-                            <button type="button"
+                            <button type="button" data-ng-disabled="disableStartButton"
                                 class="btn btn-primary btn-sm margin-top-xlg text-transform-none font-size-14"
                                 data-ng-click="moveNext()" id="solutionpack-next-btn">Let's get started<i
                                     class="fa fa-chevron-right margin-left-sm"></i></button>

--- a/widget/widgetAssets/playbookPendingDecision.directive.js
+++ b/widget/widgetAssets/playbookPendingDecision.directive.js
@@ -1,6 +1,6 @@
 /* Copyright start
   MIT License
-  Copyright (c) 2024 Fortinet Inc
+  Copyright (c) 2025 Fortinet Inc
   Copyright end */
 'use strict';
 
@@ -25,7 +25,7 @@
         unauthenticated: '=?'
       },
       controller: 'BaseCtrl',
-      templateUrl: 'widgets/installed/playbookExecutionWizard-1.0.0/widgetAssets/playbookPendingDecision.html',
+      templateUrl: 'widgets/installed/playbookExecutionWizard-1.0.1/widgetAssets/playbookPendingDecision.html',
       link: link
     };
 

--- a/widget/widgetAssets/playbookPendingDecision.html
+++ b/widget/widgetAssets/playbookPendingDecision.html
@@ -1,6 +1,6 @@
 <!-- Copyright start
   MIT License
-  Copyright (c) 2024 Fortinet Inc
+  Copyright (c) 2025 Fortinet Inc
   Copyright end -->
 <div class="{{currentTheme}}">
   <form class="noMargin playbook-pending-decision-dialog pending-decision-dialog" name="pendingDecisionForm" novalidate>

--- a/widget/widgetAssets/runningPlaybookStyle.css
+++ b/widget/widgetAssets/runningPlaybookStyle.css
@@ -1,6 +1,6 @@
 /* Copyright start
   MIT License
-  Copyright (c) 2024 Fortinet Inc
+  Copyright (c) 2025 Fortinet Inc
   Copyright end */
 
 .show-playbook-execution-logs-container {


### PR DESCRIPTION
### Mantis 
[1124008]

### PMDB
[37843]

### Issue
Playbook execution wizard retrieves several playbook details when there is pending manual input, rather than just one if the analyst clicks the button multiple times.

### Fix 
**Let's get started** button disabled after 1st click.
**executeGridPlaybook** function removed from scope as not used in html
Version updated to 1.0.1
Copyrights updated 


UTC's
- [ ]  Let's get started  button  should get disabled after 1st  click.
- [ ] It should remain disabled when PB execution response is proceeding.
- [ ] Button should enable if modal is dismissed

<img width="1452" alt="Screenshot 2025-07-10 at 12 42 37 AM" src="https://github.com/user-attachments/assets/bb361007-5e9a-4457-81ff-d3ebf865951a" />


